### PR TITLE
Improve documenation checkboxes in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,9 +17,8 @@
 
 **Have you updated the necessary documentation?**
 
-See https://github.com/rhd-gitops-example/docs
-
-[ ] Updated
+[ ] Documentation update is required by this PR.
+[ ] Documentation has been updated.
 
 **Which issue(s) this PR fixes**:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,8 +17,8 @@
 
 **Have you updated the necessary documentation?**
 
-[ ] Documentation update is required by this PR.
-[ ] Documentation has been updated.
+* [ ] Documentation update is required by this PR.
+* [ ] Documentation has been updated.
 
 **Which issue(s) this PR fixes**:
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind api-change
> /kind bug
/kind cleanup
> /kind deprecation
> /kind design
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring


**What does this PR do / why we need it**:
* Removed reference to the old doc site
* Add one more box to indicate if documentation update is required.   So, it will tell the reviewer that 1) if doc update is required 2) if doc has been updated.   (as two separate checkboxes)
**Have you updated the necessary documentation?**

See https://github.com/rhd-gitops-example/docs

[ ] Updated

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
Not applicable. 