### PR TITLE
Support status-tracker secret sharing.

### DIFF
--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -560,7 +560,7 @@ func getResourceFiles(res res.Resources) []string {
 func generateSecrets(outputs res.Resources, sa *corev1.ServiceAccount, ns string, o *BootstrapOptions) error {
 	if o.CommitStatusTracker {
 		tokenSecret, err := secrets.CreateSealedSecret(meta.NamespacedName(
-			ns, "git-host-access-token"), o.SealedSecretsService, o.GitHostAccessToken, "token")
+			ns, statustracker.CommitStatusTrackerSecret), o.SealedSecretsService, o.GitHostAccessToken, "token")
 		if err != nil {
 			return fmt.Errorf("failed to generate access token Secret: %w", err)
 		}

--- a/pkg/pipelines/statustracker/deployment.go
+++ b/pkg/pipelines/statustracker/deployment.go
@@ -16,8 +16,12 @@ import (
 
 const (
 	operatorName         = "commit-status-tracker"
-	containerImage       = "quay.io/redhat-developer/commit-status-tracker:v0.0.3"
+	containerImage       = "quay.io/redhat-developer/commit-status-tracker:v0.0.4"
 	commitStatusAppLabel = "commit-status-tracker-operator"
+
+	// CommitStatusTrackerSecret is used by commit-status-tracker to
+	// authenticate Git requests.
+	CommitStatusTrackerSecret = "git-host-access-token"
 )
 
 var (
@@ -107,6 +111,10 @@ func makeEnvironment(repoURL, driver string) []corev1.EnvVar {
 		{
 			Name:  "OPERATOR_NAME",
 			Value: operatorName,
+		},
+		{
+			Name:  "STATUS_TRACKER_SECRET",
+			Value: "git-host-access-token",
 		},
 	}
 	if host := hostFromURL(repoURL); driver != "" && host != "" {

--- a/pkg/pipelines/statustracker/deployment_test.go
+++ b/pkg/pipelines/statustracker/deployment_test.go
@@ -65,6 +65,7 @@ func TestCreateStatusTrackerDeployment(t *testing.T) {
 									Name:  "OPERATOR_NAME",
 									Value: operatorName,
 								},
+								{Name: "STATUS_TRACKER_SECRET", Value: CommitStatusTrackerSecret},
 							},
 						},
 					},
@@ -120,6 +121,10 @@ func TestMakeEnvironmentWithCustomDriver(t *testing.T) {
 		{
 			Name:  "OPERATOR_NAME",
 			Value: operatorName,
+		},
+		{
+			Name:  "STATUS_TRACKER_SECRET",
+			Value: CommitStatusTrackerSecret,
 		},
 		{
 			Name:  "GIT_DRIVERS",


### PR DESCRIPTION
Add a custom field and bump the image for commit-status-tracker to make it
easier to share secrets.

**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

commit-status-tracker supports changing the name of the secret, which makes it nicer from our side.

**Have you updated the necessary documentation?**

* [X] Documentation update is required by this PR.
* [X] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
